### PR TITLE
Maintain copies of historical resume

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -12,7 +12,7 @@ jobs:
           root_file: main.tex
           latexmk_shell_escape: true
   deploy_hash:
-    using: "composite"
+    needs: build
     steps:
     - name: Get Short SHA
       run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
@@ -26,7 +26,7 @@ jobs:
         remote_user: ${{ secrets.REMOTE_USER }}
         remote_key: ${{ secrets.DEPLOY_KEY }}
   deploy_main:
-    using: "composite"
+    needs: build
     if: github.ref == 'refs/heads/master'
     steps:
     - name: Deploy PDF

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Get Short SHA
-      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
     - name: Download PDF
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -11,12 +11,21 @@ jobs:
         with:
           root_file: main.tex
           latexmk_shell_escape: true
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with: 
+          name: resume
+          path: main.pdf
   deploy_hash:
     needs: build
     runs-on: ubuntu-latest
     steps:
     - name: Get Short SHA
       run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+    - name: Download PDF
+      uses: actions/download-artifact@v2
+      with:
+          name: resume
     - name: Deploy PDF
       uses: burnett01/rsync-deployments@5.1
       with:
@@ -31,6 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
+    - name: Download PDF
+      uses: actions/download-artifact@v2
+      with:
+          name: resume
     - name: Deploy PDF
       uses: burnett01/rsync-deployments@5.1
       with:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -11,30 +11,30 @@ jobs:
         with:
           root_file: main.tex
           latexmk_shell_escape: true
-    deploy_hash:
-      using: "composite"
-      steps:
-      - name: Get Short SHA
-        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
-      - name: Deploy PDF
-        uses: burnett01/rsync-deployments@5.1
-        with:
-          switches: -av --progress
-          path: ./main.pdf
-          remote_path: /var/www/html/u/resume/${SHORT_SHA}.pdf
-          remote_host: ${{ secrets.REMOTE_HOST }}
-          remote_user: ${{ secrets.REMOTE_USER }}
-          remote_key: ${{ secrets.DEPLOY_KEY }}
-    deploy_main:
-      using: "composite"
-      if: github.ref == 'refs/heads/master'
-      steps:
-      - name: Deploy PDF
-        uses: burnett01/rsync-deployments@5.1
-        with:
-          switches: -av --progress
-          path: ./main.pdf
-          remote_path: /var/www/html/u/resume.pdf
-          remote_host: ${{ secrets.REMOTE_HOST }}
-          remote_user: ${{ secrets.REMOTE_USER }}
-          remote_key: ${{ secrets.DEPLOY_KEY }}
+  deploy_hash:
+    using: "composite"
+    steps:
+    - name: Get Short SHA
+      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+    - name: Deploy PDF
+      uses: burnett01/rsync-deployments@5.1
+      with:
+        switches: -av --progress
+        path: ./main.pdf
+        remote_path: /var/www/html/u/resume/${SHORT_SHA}.pdf
+        remote_host: ${{ secrets.REMOTE_HOST }}
+        remote_user: ${{ secrets.REMOTE_USER }}
+        remote_key: ${{ secrets.DEPLOY_KEY }}
+  deploy_main:
+    using: "composite"
+    if: github.ref == 'refs/heads/master'
+    steps:
+    - name: Deploy PDF
+      uses: burnett01/rsync-deployments@5.1
+      with:
+        switches: -av --progress
+        path: ./main.pdf
+        remote_path: /var/www/html/u/resume.pdf
+        remote_host: ${{ secrets.REMOTE_HOST }}
+        remote_user: ${{ secrets.REMOTE_USER }}
+        remote_key: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -13,6 +13,7 @@ jobs:
           latexmk_shell_escape: true
   deploy_hash:
     needs: build
+    runs-on: ubuntu-latest
     steps:
     - name: Get Short SHA
       run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
@@ -27,6 +28,7 @@ jobs:
         remote_key: ${{ secrets.DEPLOY_KEY }}
   deploy_main:
     needs: build
+    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
     - name: Deploy PDF


### PR DESCRIPTION
This modification deploys all commits to a directory with a filename as the short SHA hash. This is useful for viewing incremental changes without needing to switch commits in Github.